### PR TITLE
Remove unneeded arguments

### DIFF
--- a/src/qt/curecoingui.cpp
+++ b/src/qt/curecoingui.cpp
@@ -645,7 +645,7 @@ if (nLastCoinStakeSearchInterval && nWeight)
     else if (IsInitialBlockDownload())
         labelStakingIcon->setToolTip(tr("Not staking because wallet is syncing"));
     else if (!nWeight)
-        labelStakingIcon->setToolTip(tr("Not staking because you don't have mature coins 1:%1 2: %2").arg(nLastCoinStakeSearchInterval).arg(nWeight));
+        labelStakingIcon->setToolTip(tr("Not staking because you don't have mature coins"));
     else
         labelStakingIcon->setToolTip(tr("Not staking")); }
 }


### PR DESCRIPTION
The staking indicator tool tip for no mature coins was erroneously given these arguments while debugging the stake weight. In my rush to debug the weight, I did the same (these arguments) in a proper location and forgot to remove the original debugging attempt code (these arguments) after the debugging was complete and when I did remove the correct debugging code. Sorry for my oversight. It was the result of sleeplessness and not carelessness.