### PR TITLE
Make menu bar display with Qt 5.2.

### DIFF
--- a/src/qt/curecoingui.cpp
+++ b/src/qt/curecoingui.cpp
@@ -308,6 +308,9 @@ void curecoinGUI::createMenuBar()
 #else
     // Get the main window's menu bar on other platforms
     appMenuBar = menuBar();
+#if QT_VERSION < QT_VERSION_CHECK(5, 3, 0)
+    appMenuBar->setNativeMenuBar(false);
+#endif
 #endif
 
     // Configure the menus


### PR DESCRIPTION
With Qt 5.2, native menubar do not display properly on Linux due to a bug in Qt.
I think it's worth fixing as I didn't realize it until (except by finding the
application quite limited) until I tested on another computer. Other user may
meet the same issue.

As 5.2 is quite old (but still in use in stable), I don't bother checking
whether it's Linux or Windows and just switch to the non-native menu bar if
version is older than 5.3.

https://forum.qt.io/topic/7276/menu-not-showing-up-in-menubar/9