### PR TITLE
Fix miniupnpc versioning.

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1028,13 +1028,17 @@ void ThreadMapPort2(void* parg)
     struct UPNPDev * devlist = 0;
     char lanaddr[64];
 
-#ifndef UPNPDISCOVER_SUCCESS
-    /* miniupnpc 1.5 */
-    devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0);
-#else
+#if MINIUPNPC_API_VERSION >= 14
+    /* miniupnpc >=1.9 */
+    int error = 0;
+    devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, 2, &error);
+#elif MINIUPNPC_API_VERSION >= 8
     /* miniupnpc 1.6 */
     int error = 0;
     devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, &error);
+#else
+    /* miniupnpc 1.5 */
+    devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0);
 #endif
 
     struct UPNPUrls urls;
@@ -1062,14 +1066,14 @@ void ThreadMapPort2(void* parg)
         }
 
         string strDesc = "curecoin " + FormatFullVersion();
-#ifndef UPNPDISCOVER_SUCCESS
-        /* miniupnpc 1.5 */
-        r = UPNP_AddPortMapping(urls.controlURL, data.first.servicetype,
-                            port.c_str(), port.c_str(), lanaddr, strDesc.c_str(), "TCP", 0);
-#else
+#if MINIUPNPC_API_VERSION >= 8
         /* miniupnpc 1.6 */
         r = UPNP_AddPortMapping(urls.controlURL, data.first.servicetype,
                             port.c_str(), port.c_str(), lanaddr, strDesc.c_str(), "TCP", 0, "0");
+#else
+        /* miniupnpc 1.5 */
+        r = UPNP_AddPortMapping(urls.controlURL, data.first.servicetype,
+                            port.c_str(), port.c_str(), lanaddr, strDesc.c_str(), "TCP", 0);
 #endif
 
         if(r!=UPNPCOMMAND_SUCCESS)
@@ -1089,14 +1093,14 @@ void ThreadMapPort2(void* parg)
             }
             if (i % 600 == 0) // Refresh every 20 minutes
             {
-#ifndef UPNPDISCOVER_SUCCESS
-                /* miniupnpc 1.5 */
-                r = UPNP_AddPortMapping(urls.controlURL, data.first.servicetype,
-                                    port.c_str(), port.c_str(), lanaddr, strDesc.c_str(), "TCP", 0);
-#else
+#if MINIUPNPC_API_VERSION >= 8
                 /* miniupnpc 1.6 */
                 r = UPNP_AddPortMapping(urls.controlURL, data.first.servicetype,
                                     port.c_str(), port.c_str(), lanaddr, strDesc.c_str(), "TCP", 0, "0");
+#else
+                /* miniupnpc 1.5 */
+                r = UPNP_AddPortMapping(urls.controlURL, data.first.servicetype,
+                                    port.c_str(), port.c_str(), lanaddr, strDesc.c_str(), "TCP", 0);
 #endif
 
                 if(r!=UPNPCOMMAND_SUCCESS)


### PR DESCRIPTION
This should fix #40.

I just used the API versioning that's in miniupnpc. It's worth noting that the header was changed back in 2015, so 2.0 is also affected.

I couldn't compile-test as I could find any compiler that accepted the CBigNum* to BIGNUM* implicit conversions, whether Ubuntu 18.04, MingW, or anything else.

