### PR TITLE
Initial POS validation was failing for POS Min Age

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,51 +2,72 @@
 
 ### Overview 
 
-If you are a newcomer, check out this [this website](http://curecoin.net/) which explains Curecoin in simple and everyday terms. You can find statistics on the current state of the Curecoin research rates [on this page](http://folding.extremeoverclocking.com/team_summary.php?s=&t=224497) and blockchain status and info on the [Block Explorer](https://chainz.cryptoid.info/cure/)
+If you are a newcomer, check out the [CureCoin website](https://curecoin.net/) which explains CureCoin in simple and everyday terms. You can find statistics on the current state of the CureCoin research rates on the [Team Stats Page](https://folding.extremeoverclocking.com/team_summary.php?s=&t=224497) and blockchain status and info on the [CureCoin Block Explorer](https://chainz.cryptoid.info/cure/)
 
-Joining the Curecoin network is easy:
+### Joining the CureCoin network is easy:
+On Windows, the [All-In-One FoldingBrowser Installer](https://github.com/Hou5e/FoldingBrowser/releases) provides a quick setup for running Folding@home to earn both CureCoin and FoldingCoin.
 
-1. Install the [Folding@home software](http://folding.stanford.edu/)
-2. Pick a username & get a [passkey](http://folding.stanford.edu/home/faq/faq-passkey/)
-3. Enter "224497" as the team number to fold under
-4. Register on [cryptobullionpools.com](https://www.cryptobullionpools.com/) with the **exact** same username 
-5. Expect your coins within 24 hours!
+### Or, setup for getting CureCoin only for running Folding@home with any username:
+1. Install the [Folding@home software](https://foldingathome.org/start-folding/), or the [F@H Chrome Browser plugin](https://chrome.google.com/webstore/detail/foldinghome/hmnbjdgjgikbkapaolimfoidihobnofo) (CPU only, better for lower power laptops)
+2. Pick a Folding@home Username & get a [Passkey](https://apps.foldingathome.org/getpasskey)
+3. Enter "224497" as the Team number to fold under
+4. Register on [cryptobullionpools.com](https://www.cryptobullionpools.com/) with the **exact** same username (50 characters or less) used in Folding@home
+5. Expect your CureCoins within 24-32 hours!
 
-### Standard Installation
+## Standard Wallet Installation
 
-1. To see all version for Windows, Mac, Linux wallet downloads visit [curecoin releases](https://github.com/cygnusxi/CurecoinSource/releases)
-2. [Windows Download](https://github.com/cygnusxi/CurecoinSource/releases/tag/v1.9.4.1)
-3. [Mac Download](https://github.com/cygnusxi/CurecoinSource/releases/tag/v1.9.4.1)
+[CureCoin GitHub Releases](https://github.com/cygnusxi/CurecoinSource/releases) has the Windows, Mac, Linux wallet downloads.  
+**CureCoin v2.0 is a mandatory update.** Older wallets need to be updated to this version (or newer) to work correctly.
 
-### Installation for Linux from source
+## Linux Installation From Source
 
-If you do not use Linux see previous section for a prebuilt wallet. There are two CureCoin Linux based clients that you can compile for yourself: one with a nice graphical interface, and one that operates entirely in the command-line. The first is highly recommended and is a good choice for most users, but expert users may prefer the command-line (headless) client instead. The GUI client is known as "curecoin-qt" and the headless client is called "curecoind". Installing either one or both is extremely simple. Just follow these directions:
+If you do not use Linux, see previous section for a prebuilt wallet. There are two CureCoin Linux based clients that you can compile for yourself: one with a nice graphical interface, and one that operates entirely in the command-line. The first is highly recommended and is a good choice for most users, but expert users may prefer the command-line (headless) client instead. The GUI client is known as "curecoin-qt" and the headless client is called "curecoind". Installing either one or both is extremely simple. Just follow these directions:
 
-* **Install from source**
+- **Install Steps For Linux**
 
-  This involves downloading the source, meeting the dependencies, compiling the code, and then installing the resulting software. 
+    This involves downloading the source, meeting the dependencies, compiling the code, and then installing the resulting software.
 
-   git clone https://github.com/cygnusxi/CurecoinSource.git
+    git clone https://github.com/cygnusxi/CurecoinSource.git
 
-    FOR THE GUI CLIENT:
-
-    > 1. **sudo apt-get install qt5-default qt5-qmake qtbase5-dev-tools qttools5-dev-tools libboost-dev libboost-system-dev libboost-filesystem-dev libboost-program-options-dev libboost-thread-dev libssl-dev libminiupnpc-dev libdb5.3++-dev dh-make build-essential**
+    ### FOR THE GUI CLIENT:
+    > 1. **sudo apt-get install qt5-default qt5-qmake qtbase5-dev-tools qttools5-dev-tools libboost-dev libboost-system-dev libboost-filesystem-dev libboost-program-options-dev libboost-thread-dev libssl-dev libminiupnpc-dev libdb5.3++-dev dh-make build-essential** &nbsp; &nbsp; &nbsp; &nbsp; {See: **NOTES** below}
     > 2. From the main directory, run the following:
     > 3. **qmake && make**
 
-    FOR THE HEADLESS CURECOIND:
-
-    > 1. **sudo apt-get install libboost-all-dev libqrencode-dev libssl-dev libdb5.3-dev libdb5.3++-dev libminiupnpc-dev dh-make build-essential**
+    ### FOR THE HEADLESS CURECOIND:
+    > 1. **sudo apt-get install libboost-all-dev libqrencode-dev libssl-dev libdb5.3-dev libdb5.3++-dev libminiupnpc-dev dh-make build-essential** &nbsp; &nbsp; &nbsp; &nbsp; {See: **NOTES** below}
     > 2. **cd src**
     > 3. **make -f makefile.unix**
-    > 4. **sudo make install** Alternatively, don't run that command and just place the binary wherever you want.
+    > 4. **sudo make install** &nbsp; &nbsp; {Alternatively, don't run that command, and just place the binary wherever you want}
 
-    On new versions of linux such a Ubuntu 18.04 or Debain 9 + "sudo apt-get install libssl1.0-dev". Use libdb4.8 or libdb5.1 on older linux versions (IE 14.04). Ubuntu 16.04 use need libdb5.3++-dev. 
+    ### NOTES:
+    - On new versions of Linux such as Ubuntu 18.04 or Debain 9, additionally install: "sudo apt-get install libssl1.0-dev"
+    - On older Linux versions, like Ubuntu 14.04, use: libdb4.8 or libdb5.1. Newer Ubuntu 16.04, use: libdb5.3++-dev.
 
-### Reporting bugs or getting assistance
+### Linux Example: Typical CureCoin GUI Wallet Install Steps on Mint 19:
+```
+sudo apt install git
+sudo apt-get install qt5-default qt5-qmake qtbase5-dev-tools qttools5-dev-tools libboost-dev libboost-system-dev libboost-filesystem-dev libboost-program-options-dev libboost-thread-dev libssl-dev libminiupnpc-dev libdb5.3++-dev dh-make build-essential
 
-General help for CureCoin can be found on the forums at https://www.curecoin.net/forum or on Discord https://discord.gg/jtztkFZ . The forum is recommended for non frequent users of irc. 
+sudo apt-get update
+sudo apt-get upgrade
+sudo apt-get install libssl1.0-dev
+[Reboot]  -NOTE: 'libssl1.0-dev' needs to be installed *after* installing the other dependencies at the beginning. If the dependencies at the beginning fail, then make sure you have updates enabled and the PC is fully updated.
+
+mkdir curecoin
+cd curecoin
+
+git clone https://github.com/cygnusxi/CurecoinSource.git
+cd CurecoinSource
+qmake
+make
+./curecoin-qt
+```
+
+### Reporting Bugs or Getting Assistance
+
+Ask questions on the [CureCoin Discord](https://discord.gg/jtztkFZ). Other general help can be searched for on the [CureCoin forums](https://curecoin.net/forum/).
 
 ### Donations
 
-Stars on this repo are appreciated as it helps improve the visibility of this repository. If you'd like to do more than that you can tip curecoins on the curecoin.net homepage. 
+Stars on this repo are appreciated as it helps improve the visibility of this repository. If you'd like to do more than that, you can tip CureCoins on the [CureCoin website](https://curecoin.net/).

--- a/src/net.h
+++ b/src/net.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2013  The curecoin developer
+// Copyright (c) 2013-2019 The Curecoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #ifndef curecoin_NET_H
@@ -314,7 +314,7 @@ public:
         }
     }
 
-    void AskFor(const CInv& inv)
+    void AskFor(const CInv& inv, bool fImmediateRetry = false)
     {
         // We're using mapAskFor as a priority queue,
         // the key is the earliest time the request can be sent
@@ -330,7 +330,10 @@ public:
         nLastTime = nNow;
 
         // Each retry is 2 minutes after the last
-        nRequestTime = std::max(nRequestTime + 2 * 60 * 1000000, nNow);
+        if (fImmediateRetry)
+            nRequestTime = nNow;
+        else
+            nRequestTime = std::max(nRequestTime + 2 * 60 * 1000000, nNow);
         mapAskFor.insert(std::make_pair(nRequestTime, inv));
     }
 


### PR DESCRIPTION
The initial POS validation was failing for POS Min Age being checked to 30 days now that it's 4 days, after the hardfork.

Details:
The error "CheckStakeKernelHash() : min age violation" was being thrown in CheckProofOfStake because the nStakeMinAge variable wasn't being updated for the changes after the hardfork.

The fix was to update this number, about where the Testnet would update this number:
if ( nBestHeight > (int)HF_BLOCK ) nStakeMinAge = 60 * 60 * 24 * 4; // 4 day min stake age hardfork
The testnet would have missed this because it was setting the value in a good location.

The Peershares fix (https://github.com/Peershares/Peershares/commit/ad71a3b1890208c9ef8ea005c76ee18fbf0b6065) looks good so far with that addition.