### PR TITLE
A dockerfile that allows the creation of a docker image of Curecoin, …

### DIFF
--- a/Dockerfile.RPi
+++ b/Dockerfile.RPi
@@ -1,0 +1,21 @@
+# Build the docker image with "sudo docker build -t curecoinpi - < Dockerfile.RPi"
+# Run with "sudo docker run --rm --net=host --env="DISPLAY" -v $HOME/.curecoin:/root/.curecoin curecoinpi"
+
+FROM ubuntu:18.04
+
+MAINTAINER neogen556@yahoo.gr
+
+RUN apt update 
+RUN apt install -y git qt5-default qt5-qmake qtbase5-dev-tools qttools5-dev-tools libboost-dev libboost-system-dev libboost-filesystem-dev libboost-program-options-dev libboost-thread-dev libssl-dev libminiupnpc-dev libdb5.3++-dev dh-make build-essential 
+RUN apt install -y libssl1.0-dev
+
+RUN git clone https://github.com/cygnusxi/CurecoinSource.git 
+
+WORKDIR CurecoinSource
+
+RUN sed -e '/msse2/ s/^#*/#/' -i curecoin-qt.pro
+
+RUN qmake "USE_UPNP=-"
+RUN make
+
+ENTRYPOINT ["./curecoin-qt"]


### PR DESCRIPTION
…capable of running on a Raspberry Pi.

One can build the docker image with "sudo docker build -t curecoinpi - < Dockerfile.RPi"
It ends with an entrypoint, so it will act as an executable, running qurecoin-qt every time it is run
Run it with "sudo docker run --rm --net=host --env="DISPLAY" -v $HOME/.curecoin:/root/.curecoin curecoinpi"

DISPLAY is set up to run the GUI app, and the local home folder is mounted so that wallet and db changes are stored and read from the host (user's) file structure, not the image's.

It could also be use to create a docker image for x86 linux systems, though I's remove the "RUN sed..." line to get back the SSE2 instruction set.