### PR TITLE
Dockerfile for running curecoind on a raspberry pi

### DIFF
--- a/Dockerfile.headless.rpi
+++ b/Dockerfile.headless.rpi
@@ -1,0 +1,20 @@
+FROM raspbian/stretch as base
+
+WORKDIR app
+
+RUN apt-get update && \
+    apt-get -qy install libboost-all-dev libqrencode-dev libssl-dev libdb5.3-dev libdb5.3++-dev libminiupnpc-dev dh-make build-essential zlib1g-dev libtool
+
+COPY src /app
+
+RUN STATIC=static make -f makefile.raspberrypi
+
+FROM raspbian/stretch as app
+
+WORKDIR app
+
+COPY --from=base /app/curecoind /app/
+
+VOLUME /root/.curecoin
+
+CMD ['curecoind', '-printtoconsole']


### PR DESCRIPTION
This results in a roughly 200Mb image, thanks to multistage build.

I'm currently running it with a docker-compose file on portainer like this.

```
---
version: "2.1"
services:
  curecoin:
    image: curecoin
    container_name: curecoin
    volumes:
      - /home/pi/portainer/curecoin:/root/.curecoin
    restart: unless-stopped
```