### PR TITLE
Update wallet.cpp for merge POS inputs automatic up to ~60 coins (POS diff *10) 

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1476,7 +1476,7 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
     const CBlockIndex* pIndex0 = GetLastBlockIndex(pindexBest, false);
     int64 nCombineThreshold = 0;
     if(pIndex0->pprev)
-        nCombineThreshold = GetProofOfWorkReward(pIndex0->nHeight, MIN_TX_FEE, pIndex0->pprev->GetBlockHash()) / 3;
+        nCombineThreshold = GetProofOfWorkReward(pIndex0->nHeight, MIN_TX_FEE, pIndex0->pprev->GetBlockHash()) * 10;
 
     CBigNum bnTargetPerCoinDay;
     bnTargetPerCoinDay.SetCompact(nBits);


### PR DESCRIPTION
this change will lead to when i find a POS block with a input size smaller then acual diff *10 it will add another input and merge it until max 100 inputs are reached or all inputs together are bigger then diff * 10

at actual POS diff this would lead to coinpile size of around 60 CURE

why this change is important?

first of all its non mandatory this means each wallet can have his own prefered setting

i for example tested it with  * 100 and the result is like this:
https://chainz.cryptoid.info/cure/block.dws?593145.htm

but for everyone use *10 is better

at actual setting at a POS diff pof like 6 coin pile would split down until 2 coin size and not merge together

if u have many coins this make ur wallet very slow as it holds like many thousand unspend transactions

as im with DMD Diamond since 2013 im used to POS coincode our original staking engine was pretty similar to what u use now

take it as improvement or leave it as every user can change this on his own and compile wallet its no issue for experenced users

but it make life much more easy for the non techie owner of like 100k cure where i guess a few exist