### PR TITLE
Add getstakinginfo to commands list

### DIFF
--- a/src/curecoinrpc.cpp
+++ b/src/curecoinrpc.cpp
@@ -213,6 +213,7 @@ static const CRPCCommand vRPCCommands[] =
     { "gethashespersec",        &gethashespersec,        true,   false },
     { "getinfo",                &getinfo,                true,   false },
     { "getmininginfo",          &getmininginfo,          true,   false },
+    { "getstakinginfo",         &getstakinginfo,         true,   false },
     { "getnetworkhashps",       &getnetworkhashps,       true,   false },
     { "getnewaddress",          &getnewaddress,          true,   false },
     { "getnewpubkey",           &getnewpubkey,           true,   false },

--- a/src/curecoinrpc.h
+++ b/src/curecoinrpc.h
@@ -163,6 +163,7 @@ extern json_spirit::Value getgenerate(const json_spirit::Array& params, bool fHe
 extern json_spirit::Value setgenerate(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value gethashespersec(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getmininginfo(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value getstakinginfo(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getnetworkhashps(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getwork(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value getworkex(const json_spirit::Array& params, bool fHelp);


### PR DESCRIPTION
`getstakinginfo` exists in `src/rpcmining.cpp` next to `getmininginfo` and `getworkex`, but it isn't part of the commands list or used anywhere else. Likely this was an oversight and `getstakinginfo` was simply forgotten from the commands list.