### PR TITLE
Allow compilation with glibc 2.41, boost 1.86, and db 6.2

### DIFF
--- a/src/curecoinrpc.cpp
+++ b/src/curecoinrpc.cpp
@@ -765,12 +765,20 @@ void ThreadRPCServer2(void* parg)
         context.set_options(boost::asio::ssl::context::no_sslv2);
 
         boost::filesystem::path pathCertFile(GetArg("-rpcsslcertificatechainfile", "server.cert"));
+#if BOOST_VERSION >= 107900
+        if (!pathCertFile.is_absolute()) pathCertFile = boost::filesystem::path(GetDataDir()) / pathCertFile;
+#else
         if (!pathCertFile.is_complete()) pathCertFile = boost::filesystem::path(GetDataDir()) / pathCertFile;
+#endif
         if (boost::filesystem::exists(pathCertFile)) context.use_certificate_chain_file(pathCertFile.string());
         else printf("ThreadRPCServer ERROR: missing server certificate file %s\n", pathCertFile.string().c_str());
 
         boost::filesystem::path pathPKFile(GetArg("-rpcsslprivatekeyfile", "server.pem"));
+#if BOOST_VERSION >= 107900
+        if (!pathPKFile.is_absolute()) pathPKFile = boost::filesystem::path(GetDataDir()) / pathPKFile;
+#else
         if (!pathPKFile.is_complete()) pathPKFile = boost::filesystem::path(GetDataDir()) / pathPKFile;
+#endif
         if (boost::filesystem::exists(pathPKFile)) context.use_private_key_file(pathPKFile.string(), boost::asio::ssl::context::pem);
         else printf("ThreadRPCServer ERROR: missing server private key file %s\n", pathPKFile.string().c_str());
 

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -44,7 +44,7 @@ void CDBEnv::EnvShutdown()
     if (ret != 0)
         printf("EnvShutdown exception: %s (%d)\n", DbEnv::strerror(ret), ret);
     if (!fMockDb)
-        DbEnv(0).remove(strPath.c_str(), 0);
+        DbEnv(0u).remove(strPath.c_str(), 0);
 }
 
 CDBEnv::CDBEnv() : dbenv(DB_CXX_NO_EXCEPTIONS)

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -44,7 +44,11 @@ void CDBEnv::EnvShutdown()
     if (ret != 0)
         printf("EnvShutdown exception: %s (%d)\n", DbEnv::strerror(ret), ret);
     if (!fMockDb)
+#if DB_VERSION_MAJOR >= 6
         DbEnv(0u).remove(strPath.c_str(), 0);
+#else
+        DbEnv(0).remove(strPath.c_str(), 0);
+#endif
 }
 
 CDBEnv::CDBEnv() : dbenv(DB_CXX_NO_EXCEPTIONS)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -12,7 +12,9 @@
 #include "checkpoints.h"
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
+#if BOOST_VERSION <= 108300
 #include <boost/filesystem/convenience.hpp>
+#endif
 #include <boost/interprocess/sync/file_lock.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <openssl/crypto.h>

--- a/src/strlcpy.h
+++ b/src/strlcpy.h
@@ -16,6 +16,8 @@
 #ifndef curecoin_STRLCPY_H
 #define curecoin_STRLCPY_H
 
+#if (__GLIBC__ == 2) && (__GLIBC_MINOR__ < 38)
+
 #include <stdlib.h>
 #include <string.h>
 
@@ -87,4 +89,6 @@ inline size_t strlcat(char *dst, const char *src, size_t siz)
 
     return(dlen + (s - src)); /* count does not include NUL */
 }
+#endif
+
 #endif

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1078,7 +1078,11 @@ const boost::filesystem::path &GetDataDir(bool fNetSpecific)
 boost::filesystem::path GetConfigFile()
 {
     boost::filesystem::path pathConfigFile(GetArg("-conf", "curecoin.conf"));
+#if BOOST_VERSION >= 107900
+    if (!pathConfigFile.is_absolute()) pathConfigFile = GetDataDir(false) / pathConfigFile;
+#else
     if (!pathConfigFile.is_complete()) pathConfigFile = GetDataDir(false) / pathConfigFile;
+#endif
     return pathConfigFile;
 }
 
@@ -1109,7 +1113,11 @@ void ReadConfigFile(std::map<std::string, std::string>& mapSettingsRet,
 boost::filesystem::path GetPidFile()
 {
     boost::filesystem::path pathPidFile(GetArg("-pid", "curecoind.pid"));
+#if BOOST_VERSION >= 107900
+    if (!pathPidFile.is_absolute()) pathPidFile = GetDataDir() / pathPidFile;
+#else
     if (!pathPidFile.is_complete()) pathPidFile = GetDataDir() / pathPidFile;
+#endif
     return pathPidFile;
 }
 

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -645,7 +645,9 @@ bool BackupWallet(const CWallet& wallet, const std::string& strDest)
                     pathDest /= wallet.strWalletFile;
 
                 try {
-#if BOOST_VERSION >= 104000
+#if BOOST_VERSION >= 108500
+                    boost::filesystem::copy_file(pathSrc, pathDest, boost::filesystem::copy_options::overwrite_existing);
+#elif BOOST_VERSION >= 104000
                     boost::filesystem::copy_file(pathSrc, pathDest, boost::filesystem::copy_option::overwrite_if_exists);
 #else
                     boost::filesystem::copy_file(pathSrc, pathDest);


### PR DESCRIPTION
These changes allow me to compile the source code on a rolling release Linux distro. (Arch, if that matters.) Because it is a rolling release distro this means you always get the latest and greatest libraries, which may require tweaks to the code.

I tried to make sure the changes are backward compatible by checking the library versions and only making the change if it applies to the library version.

Two things to note:
1) The changes required to compile with Boost 1.87 are more complicated than simple substitutions, and are beyond my coding skills.
2) This has not been tested with UPNP support, as I compile the code without UPNP support. (`make -f makefile.unix USE_UPNP=-`)

The actual package versions in my current build environment:
```
$ pacman -Q | grep -E "boost|glibc|^db |pnp"
boost 1.86.0-6
boost-libs 1.86.0-6
db 6.2.32-1
glibc 2.41+r9+ga900dbaf70f0-1
```